### PR TITLE
Progress towards Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,83 @@
+name: Run tests
+
+on: [pull_request]
+
+permissions:
+  checks: write
+  pull-requests: write
+
+jobs:
+  python-tox-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python_version:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+          - "3.12"
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup Python ${{ matrix.python_version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y libarchive-dev
+
+      - name: Install tox/wheel/setuptools
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel setuptools
+          pip install tox
+
+      - name: List tox environments
+        run: |
+          # runs tox
+          tox -l
+
+      - name: Install dependencies from tox
+        timeout-minutes: 15
+        run: |
+          # runs tox with exhaustive package installation
+          tox -e ${{ matrix.python_version }} --notest -vv
+
+      - name: Run tests from tox
+        timeout-minutes: 30
+        run: |
+          # disables the GDrive tests
+          # runs tox
+          tox -l
+          tox -e ${{ matrix.python_version }}
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v2
+        with:
+          name: Tox test results (${{ matrix.python_version }})
+          path: ${{ github.workspace }}/.tox/**/tmp/*.xml
+
+  publish-test-results:
+    name: 'publish unit tests results'
+    needs: [python-tox-tests]
+    runs-on: ubuntu-latest
+    # previous jobs might be skipped, we don't need to run this job then
+    if: success() || failure()
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: artifacts
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: artifacts/**/*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.tox
+build
+_version.py
+pygsl_lite.egg-info

--- a/gsl_dist/array_includes.py
+++ b/gsl_dist/array_includes.py
@@ -1,8 +1,4 @@
-"""
-
-	       WARNING: File Generated during build. DO NOT MODIFY!!!
-	"""
+import numpy as np
 
 array_include_dirs = []
-from numpy.distutils.misc_util import get_numpy_include_dirs
-array_include_dirs = get_numpy_include_dirs()
+array_include_dirs.append(np.get_include())

--- a/gsl_dist/gsl_Extension.py
+++ b/gsl_dist/gsl_Extension.py
@@ -16,7 +16,6 @@ import os.path
 import re
 import string
 import types
-import imp
 from sys import argv,version_info
 
 from gsl_Location import gsl_Location
@@ -108,12 +107,7 @@ class gsl_Extension(Extension):
 	    # test if Numeric module is available
 	    if define_macros is None:
 		    define_macros=[]
-	    try:
-		    imp.find_module("Numeric")
-		    define_macros = define_macros + [("NUMERIC",1),]
-	    except ImportError:	    
-		    define_macros = define_macros + [("NUMERIC",0), ]
-
+	    define_macros = define_macros + [("NUMERIC",0), ]
 	    if undef_macros == None:
 		    undef_macros = []
 	    if 'NDEBUG' not in undef_macros:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 
 
 [project.urls]
-    homepage = "https://github.com/SergeiOssokine/pygsl_lite"
+    homepage = "https://github.com/AEI-ACR/pygsl_lite"
 
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@
 [project.urls]
     homepage = "https://github.com/AEI-ACR/pygsl_lite"
 
-
 [tool.setuptools_scm]
     write_to = "pygsl_lite/_version.py"
+
+[tool.pytest.ini_options]
+    minversion = "6.0"
+    testpaths = [
+        "test",
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,17 @@
+[tox]
+requires =
+    tox>=4
+env_list =
+    py{39,310,311,312}
+skip_missing_interpreters = true
+
+[default]
+
+[testenv]
+description     = run unit tests
+package         = wheel
+deps            =
+    pytest
+
+commands        =
+    pytest --junitxml={env_tmp_dir}/junit-{env_name}.xml {posargs:test}


### PR DESCRIPTION
Python 3.12 brings some forced deprecation:
- `imp` module is [gone](https://docs.python.org/3.12/whatsnew/3.12.html#imp)
- `numpy.distutils` is [gone](https://numpy.org/doc/stable/reference/distutils_status_migration.html) 
Fortunately we only used the former to locate `Numeric` which at this point we can assume will _not_ be used (long live numpy). For the latter we just needed to get the numpy includes.

Note that `pyseobnr` upstream is blocked by `numba` [compatibility issues](https://github.com/numba/numba/issues/9197)

